### PR TITLE
Add a github action to push to the Azure mirror

### DIFF
--- a/.github/workflows/mirror-to-azure.yml
+++ b/.github/workflows/mirror-to-azure.yml
@@ -1,0 +1,30 @@
+name: Mirror to Azure Repository
+
+on:
+  push:
+    branches:
+      - main
+      - staging
+      - devqa
+
+jobs:
+  mirror:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Push to Azure Repository
+        env:
+          AZURE_PAT: ${{ secrets.AZURE_PAT }}
+          AZURE_REPO_URL: ${{ vars.AZURE_REPO_URL }}
+        run: |
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+          git remote add azure $AZURE_REPO_URL
+
+          for branch in main staging devqa; do
+            git checkout $branch
+            git -c http.extraheader="AUTHORIZATION: bearer $AZURE_PAT" push azure HEAD:$branch
+          done


### PR DESCRIPTION
## What?
Add a GitHub Action to push the most recent state of the three long lived branches to the Azure mirror.

## Why?
In order to keep being able to bring new features from the upstream public repo into the fork, and having the ease of integration between Azure repos and pipelines.
